### PR TITLE
Add sessionToken to signed request

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,4 +42,25 @@ describe('Token_Generation_Test', function () {
             'LVNpZ25hdHVyZT1mZjFjODljMTZmMjUyNzVmOGE0YzczMTE2NzhmNDQ3NzIy' +
             'NjQ2ZDY0MzU4ODg1NGExMTRkMTY4YjA2MmM0YmYw');
     });
+
+    it('renew_token_with_sessionToken', async function () {
+        EKSToken.config = {
+            accessKeyId: 'AKID',
+            secretAccessKey: 'SECRET',
+            sessionToken: 'FwoGZXIvYXdzEMP//////////wEaDLuLD7I1gA6LW1mZcSKxAZWj_trunc',
+            region: 'us-west-2'
+        };
+        let token = await EKSToken.renew('eks-cluster', '60', '20200930T093726Z');
+        expect(token).to.be.equal('k8s-aws-v1.' +
+            'aHR0cHM6Ly9zdHMudXMtd2VzdC0yLmFtYXpvbmF3cy5jb20vP0FjdGlvbj1H' +
+            'ZXRDYWxsZXJJZGVudGl0eSZWZXJzaW9uPTIwMTEtMDYtMTUmWC1BbXotQWxn' +
+            'b3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lE' +
+            'JTJGMjAyMDA5MzAlMkZ1cy13ZXN0LTIlMkZzdHMlMkZhd3M0X3JlcXVlc3Qm' +
+            'WC1BbXotRGF0ZT0yMDIwMDkzMFQwOTM3MjZaJlgtQW16LUV4cGlyZXM9NjAm' +
+            'WC1BbXotU2VjdXJpdHktVG9rZW49RndvR1pYSXZZWGR6RU1QJTJGJTJGJTJG' +
+            'JTJGJTJGJTJGJTJGJTJGJTJGJTJGd0VhREx1TEQ3STFnQTZMVzFtWmNTS3hB' +
+            'WldqX3RydW5jJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCUzQngtazhzLWF3' +
+            'cy1pZCZYLUFtei1TaWduYXR1cmU9OWQzZDU5ZmVlNjk5NDUwMjI0YjcwOTli' +
+            'YjZkY2U1YmNhMGE3Njc3ODcwMjMyYTNjMTczMDE2MTNmMDAxMjYxNQ');
+    });
 });


### PR DESCRIPTION
Hey @qinshuang1998

Nice work on this library :heart:

This PR adds a `sessionToken` to the pre-signed URL so that we can generate a token similar to the AWS CLI:

```bash
aws eks get-token --region us-east-2 --cluster-name my-eks-cluster --role arn:aws:iam::123456128631:role/cluster-role
```